### PR TITLE
fix: report 페이지 week와 month 올바르게 렌더링

### DIFF
--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -228,7 +228,19 @@ const ReportPage = () => {
         </BlockComponent>
       </div>
 
-      <Title>이번 주 목표 달성률이 높아요! 계속해서 도전하세요!</Title>
+      <Title>
+        이번 {!isToggle ? "주" : "달"} 목표 달성률이{" "}
+        {!reportDetailData
+          ? "없네요!"
+          : !isToggle
+          ? reportDetailData?.total_weekly_progress >= 50
+            ? "높아요!"
+            : "낮아요!"
+          : reportDetailData?.total_monthly_progress >= 50
+          ? "높아요!"
+          : "낮아요!"}{" "}
+        계속해서 도전하세요!
+      </Title>
       <div className="flex gap-2 mb-6">
         {!isToggle ? (
           <>
@@ -321,7 +333,7 @@ const ReportPage = () => {
 
           <BlockComponent>
             <BlockTitle className="mt-5 mb-5">
-              이번 주의 내 또래 친구들의 목표에요
+              이번 {!isToggle ? "주" : "달"}의 내 또래 친구들의 목표에요
             </BlockTitle>
             <GoalListItem
               goal="일주일에 5개 단어씩 외국어 단어장에 추가 후 복습"


### PR DESCRIPTION
## 🚨 Fix
- 주간 <-> 월간 토글 올바르게 렌더링
- 달성률 50% 이하 -> 높아요!  미만 -> 낮아요!로 출력

<br/>

### 🥝 스크린샷
- week

![image](https://github.com/user-attachments/assets/f020984e-7bb8-4cd0-8d45-ad0e5f26fa16)


- month

![image](https://github.com/user-attachments/assets/faacde35-57f2-491c-8062-ce8a9f7c1b52)


<br/>

### 🥝 영상


https://github.com/user-attachments/assets/b3e87ef0-c261-4acd-b781-070c135f0554




